### PR TITLE
Update extension-marketplace.md for download VSIX option

### DIFF
--- a/docs/configure/extensions/extension-marketplace.md
+++ b/docs/configure/extensions/extension-marketplace.md
@@ -345,10 +345,7 @@ You may see this error if your machine is going through a proxy server to access
 
 Some users prefer to download an extension once from the Marketplace and then install it to multiple VS Code instances from a local share. This is useful when there are connectivity concerns or if your development team wants to use a fixed set of extensions.
 
-To download an extension, search for it in the Extensions view, right-click on an extension from the results, and select **Download VSIX**.
-
-> [!NOTE]
-> The download option is available as of VS Code release 1.96, and is only available for extensions that are not installed yet.
+To download an extension, search for it in the Extensions view, right-click on an extension from the results, and select **Download VSIX** or **Download Specific Version VSIX**.
 
 ### Can I stop VS Code from providing extension recommendations?
 


### PR DESCRIPTION
The download VSIX option was re-added to installed extentions in 1.101.0, plus a new option to download a specific VSIX version. 

This PR simply removes the note that as of 1.96.0 the download VSIX option is no longer present. 

I thought maybe changing it to say in versions 1.96-1.100 the option is not there for installed extensions, but don't think it would be necessary.

https://github.com/microsoft/vscode/issues/240231